### PR TITLE
Update v3-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/swap-router-contracts": "1.1.0",
     "@uniswap/v2-sdk": "^3.0.1",
-    "@uniswap/v3-sdk": "^3.7.1"
+    "@uniswap/v3-sdk": "^3.8.3"
   },
   "devDependencies": {
     "@types/jest": "^24.0.25",


### PR DESCRIPTION
The v3-sdk version must be the same in both Uniswap/interface and Uniswap/router-sdk

Otherwise the [pool.ts](https://github.com/Uniswap/v3-sdk/blob/main/src/entities/pool.ts#L52) classes are different and casting throws a typescript error. 

[Example of where typescript complains](https://github.com/Uniswap/interface/blob/main/src/lib/hooks/swap/useSwapApproval.ts#L113)