### PR TITLE
Add `@ethersproject/solidity`, `tiny-invariant`, `jsbi` explicit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,13 @@
   "license": "MIT",
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
+    "@ethersproject/solidity": "^5.0.9",
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/swap-router-contracts": "1.1.0",
     "@uniswap/v2-sdk": "^3.0.1",
-    "@uniswap/v3-sdk": "^3.8.3"
+    "@uniswap/v3-sdk": "^3.8.3",
+    "jsbi": "^3.1.4",
+    "tiny-invariant": "^1.1.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.25",


### PR DESCRIPTION
# Issue

- `jsbi@^3.1.4` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `@ethersproject/solidity@^5.0.9` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `tiny-invariant@^1.1.0` dependency is used in the package without being defined as an explicit dependency in `package.json`

This impacts developers using this package as dependency resolvers (such as `npm` or `yarn`) won't automatically install missing dependencies, or will install it with incorrect (and thus perhaps incompatible) versions

# Fix

- This PR adds the missing dependencies to `package.json` without impacting the current state of `yarn.lock`