### PR TITLE
Fix calculation for Trade.minimumAmountOut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "publishConfig": {
     "access": "public"

--- a/src/entities/trade.test.ts
+++ b/src/entities/trade.test.ts
@@ -830,6 +830,10 @@ describe('Trade', () => {
         expect(() => exactInV3.worstExecutionPrice(new Percent(-1, 100))).toThrow('SLIPPAGE_TOLERANCE')
         expect(() => exactInMixed.worstExecutionPrice(new Percent(-1, 100))).toThrow('SLIPPAGE_TOLERANCE')
       })
+      it('throws if greater than 100%', () => {
+        expect(() => exactInV3.worstExecutionPrice(new Percent(200, 100))).toThrow('SLIPPAGE_TOLERANCE')
+        expect(() => exactInMixed.worstExecutionPrice(new Percent(200, 100))).toThrow('SLIPPAGE_TOLERANCE')
+      })
       it('returns exact if 0', () => {
         expect(exactInV3.worstExecutionPrice(new Percent(0, 100))).toEqual(exactInV3.executionPrice)
         expect(exactInMixed.worstExecutionPrice(new Percent(0, 100))).toEqual(exactInV3.executionPrice)
@@ -837,23 +841,17 @@ describe('Trade', () => {
       it('returns exact if nonzero', () => {
         expect(exactInV3.worstExecutionPrice(new Percent(0, 100))).toEqual(new Price(token0, token2, 100, 69))
         expect(exactInV3.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 100, 65))
-        expect(exactInV3.worstExecutionPrice(new Percent(200, 100))).toEqual(new Price(token0, token2, 100, 23))
         expect(exactInMixed.worstExecutionPrice(new Percent(0, 100))).toEqual(new Price(token0, token2, 100, 69))
         expect(exactInMixed.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 100, 65))
-        expect(exactInMixed.worstExecutionPrice(new Percent(200, 100))).toEqual(new Price(token0, token2, 100, 23))
       })
       it('returns exact if nonzero with multiple routes', () => {
         expect(exactInMultiRoute.worstExecutionPrice(new Percent(0, 100))).toEqual(new Price(token0, token2, 100, 69))
         expect(exactInMultiRoute.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 100, 65))
-        expect(exactInMultiRoute.worstExecutionPrice(new Percent(200, 100))).toEqual(new Price(token0, token2, 100, 23))
         expect(exactInMultiMixedRoute.worstExecutionPrice(new Percent(0, 100))).toEqual(
           new Price(token0, token2, 100, 69)
         )
         expect(exactInMultiMixedRoute.worstExecutionPrice(new Percent(5, 100))).toEqual(
           new Price(token0, token2, 100, 65)
-        )
-        expect(exactInMultiMixedRoute.worstExecutionPrice(new Percent(200, 100))).toEqual(
-          new Price(token0, token2, 100, 23)
         )
       })
     })
@@ -894,6 +892,9 @@ describe('Trade', () => {
       it('throws if less than 0', () => {
         expect(() => exactOut.worstExecutionPrice(new Percent(-1, 100))).toThrow('SLIPPAGE_TOLERANCE')
       })
+      it('throws if greater than 100%', () => {
+        expect(() => exactOut.worstExecutionPrice(new Percent(200, 100))).toThrow('SLIPPAGE_TOLERANCE')
+      })
       it('returns exact if 0', () => {
         expect(exactOut.worstExecutionPrice(new Percent(0, 100))).toEqual(exactOut.executionPrice)
       })
@@ -904,9 +905,6 @@ describe('Trade', () => {
         expect(
           exactOut.worstExecutionPrice(new Percent(5, 100)).equalTo(new Price(token0, token2, 163, 100))
         ).toBeTruthy()
-        expect(
-          exactOut.worstExecutionPrice(new Percent(200, 100)).equalTo(new Price(token0, token2, 468, 100))
-        ).toBeTruthy()
       })
       it('returns exact if nonzero with multiple routes', () => {
         expect(
@@ -914,9 +912,6 @@ describe('Trade', () => {
         ).toBeTruthy()
         expect(
           exactOutMultiRoute.worstExecutionPrice(new Percent(5, 100)).equalTo(new Price(token0, token2, 163, 100))
-        ).toBeTruthy()
-        expect(
-          exactOutMultiRoute.worstExecutionPrice(new Percent(200, 100)).equalTo(new Price(token0, token2, 468, 100))
         ).toBeTruthy()
       })
     })
@@ -952,13 +947,15 @@ describe('Trade', () => {
       it('throws if less than 0', () => {
         expect(() => exactIn.worstExecutionPrice(new Percent(-1, 100))).toThrow('SLIPPAGE_TOLERANCE')
       })
+      it('throws if greater than 100%', () => {
+        expect(() => exactIn.worstExecutionPrice(new Percent(200, 100))).toThrow('SLIPPAGE_TOLERANCE')
+      })
       it('returns exact if 0', () => {
         expect(exactIn.worstExecutionPrice(new Percent(0, 100))).toEqual(exactIn.executionPrice)
       })
       it('returns exact if nonzero', () => {
         expect(exactIn.worstExecutionPrice(new Percent(0, 100))).toEqual(new Price(token0, token2, 350, 250))
-        expect(exactIn.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 350, 238))
-        expect(exactIn.worstExecutionPrice(new Percent(200, 100))).toEqual(new Price(token0, token2, 350, 83))
+        expect(exactIn.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 350, 237))
       })
     })
 
@@ -985,13 +982,15 @@ describe('Trade', () => {
       it('throws if less than 0', () => {
         expect(() => exactIn.worstExecutionPrice(new Percent(-1, 100))).toThrow('SLIPPAGE_TOLERANCE')
       })
+      it('throws if greater than 100%', () => {
+        expect(() => exactIn.worstExecutionPrice(new Percent(200, 100))).toThrow('SLIPPAGE_TOLERANCE')
+      })
       it('returns exact if 0', () => {
         expect(exactIn.worstExecutionPrice(new Percent(0, 100))).toEqual(exactIn.executionPrice)
       })
       it('returns exact if nonzero', () => {
         expect(exactIn.worstExecutionPrice(new Percent(0, 100))).toEqual(new Price(token0, token2, 256, 200))
         expect(exactIn.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 256, 190))
-        expect(exactIn.worstExecutionPrice(new Percent(200, 100))).toEqual(new Price(token0, token2, 256, 66))
       })
     })
 
@@ -1018,13 +1017,15 @@ describe('Trade', () => {
       it('throws if less than 0', () => {
         expect(() => exactOut.worstExecutionPrice(new Percent(-1, 100))).toThrow('SLIPPAGE_TOLERANCE')
       })
+      it('throws if greater than 100%', () => {
+        expect(() => exactOut.worstExecutionPrice(new Percent(200, 100))).toThrow('SLIPPAGE_TOLERANCE')
+      })
       it('returns exact if 0', () => {
         expect(exactOut.worstExecutionPrice(new Percent(0, 100))).toEqual(exactOut.executionPrice)
       })
       it('returns exact if nonzero', () => {
         expect(exactOut.worstExecutionPrice(new Percent(0, 100))).toEqual(new Price(token0, token2, 256, 200))
         expect(exactOut.worstExecutionPrice(new Percent(5, 100))).toEqual(new Price(token0, token2, 268, 200))
-        expect(exactOut.worstExecutionPrice(new Percent(200, 100))).toEqual(new Price(token0, token2, 768, 200))
       })
     })
   })
@@ -1049,7 +1050,9 @@ describe('Trade', () => {
       it('throws if less than 0', () => {
         expect(() => trade.minimumAmountOut(new Percent(JSBI.BigInt(-1), 100))).toThrow('SLIPPAGE_TOLERANCE')
       })
-
+      it('throws if greater than 100%', () => {
+        expect(() => trade.minimumAmountOut(new Percent(JSBI.BigInt(-1), 100))).toThrow('SLIPPAGE_TOLERANCE')
+      })
       it('returns exact if 0', () => {
         expect(trade.minimumAmountOut(new Percent(JSBI.BigInt(0), 100))).toEqual(trade.outputAmount)
       })
@@ -1057,9 +1060,6 @@ describe('Trade', () => {
       it('returns exact if nonzero', () => {
         expect(trade.minimumAmountOut(new Percent(JSBI.BigInt(5), 100))).toEqual(
           CurrencyAmount.fromRawAmount(token1, 285) // 300 * 0.95
-        )
-        expect(trade.minimumAmountOut(new Percent(JSBI.BigInt(200), 100))).toEqual(
-          CurrencyAmount.fromRawAmount(token1, 100)
         )
       })
 

--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -189,14 +189,12 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
    * @returns The amount out
    */
   public minimumAmountOut(slippageTolerance: Percent, amountOut = this.outputAmount): CurrencyAmount<TOutput> {
-    invariant(!slippageTolerance.lessThan(ZERO), 'SLIPPAGE_TOLERANCE')
+    invariant(!(slippageTolerance.lessThan(ZERO) || slippageTolerance.greaterThan(ONE)), 'SLIPPAGE_TOLERANCE')
     if (this.tradeType === TradeType.EXACT_OUTPUT) {
       return amountOut
     } else {
-      const slippageAdjustedAmountOut = new Fraction(ONE)
-        .add(slippageTolerance)
-        .invert()
-        .multiply(amountOut.quotient).quotient
+      const slippageAdjustedAmountOut = new Fraction(ONE).subtract(slippageTolerance).multiply(amountOut).quotient
+
       return CurrencyAmount.fromRawAmount(amountOut.currency, slippageAdjustedAmountOut)
     }
   }


### PR DESCRIPTION
Fixes: #43

## Description
The function had a math mistake, but the tests did not catch it because the tests were only checking for small slippage rates. When the slippage rate is 5% or less, the tests did not fail because the result was almost correct when rounded to the nearest whole number. However, when the slippage rate increased, the problem became more obvious.

Additionally, I made a change to the function to prevent a slippage rate of over 100%. It's impossible to lose more than 100% of your money, so setting a slippage rate of over 100% should generate an error.

I had to verify this change, so I modified the tests to reflect these updates.
## Screen capture

Here is a manual test on the Uniswap Interface
| Before  |  After  |
|:-------:|:------:|
| <img width="400" alt="Screenshot" src="https://github.com/Uniswap/router-sdk/assets/89173284/473f9ff1-fd3f-431f-ac3b-002863242516"> | <img width="400" alt="Screenshot" src="https://github.com/Uniswap/router-sdk/assets/89173284/b1f4ce66-e5ae-4826-b712-df703c65434e"> |


## Test plan

### Reproducing the error

1. Go to app.uniswap.org
2. Add two tokens to swap (Easier to test with two stablecoins like USDC & DAI)
3. Add Custom Slippage (Easier to test with a round number like 50%)
4. Open SwapDetailsDropdown see the incorrect number in the "Minimum output" row


### Automated testing
- [ ] Run ``` yarn test ``` in your local env to make sure all test pass