### PR TITLE
chore: add error message for when `new Trade()` is called without any routes

### DIFF
--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -81,6 +81,11 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
         })
       }
     }
+
+    if (this.swaps.length === 0) {
+      throw new Error("No routes provided when calling Trade constructor")
+    }
+
     this.tradeType = tradeType
 
     // each route must have the same input and output currency


### PR DESCRIPTION
Without this additional `throw`, we were seeing a `Cannot read property 'inputAmount' of undefined` error. This new error message makes it easier to debug if it happens again.