### PR TITLE
chore: add error message for when `new Trade()` is called without any routes

### DIFF
--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -81,6 +81,11 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
         })
       }
     }
+
+    if (this.swaps.length === 0) {
+      throw new Error("No routes provided when calling Trade constructor")
+    }
+
     this.tradeType = tradeType
 
     // each route must have the same input and output currency

--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -83,7 +83,7 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
     }
 
     if (this.swaps.length === 0) {
-      throw new Error("No routes provided when calling Trade constructor")
+      throw new Error('No routes provided when calling Trade constructor')
     }
 
     this.tradeType = tradeType


### PR DESCRIPTION
Without this additional `throw`, we were seeing a `Cannot read property 'inputAmount' of undefined` error in our frontend apps. This happens because `router-sdk` is doing `const inputCurrency = this.swaps[0].inputAmount.currency` without checking first if `this.swaps[0]` exists.

This new error message makes it easier to debug if it happens again.