### PR TITLE
Add `module` and `jsbi` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "module": "dist/router-sdk.esm.js",
   "files": [
     "dist"
   ],
@@ -30,7 +31,8 @@
     "@uniswap/sdk-core": "^4.0.7",
     "@uniswap/swap-router-contracts": "^1.1.0",
     "@uniswap/v2-sdk": "^3.2.0",
-    "@uniswap/v3-sdk": "^3.10.0"
+    "@uniswap/v3-sdk": "^3.10.0",
+    "jsbi": "^3.1.4"
   },
   "devDependencies": {
     "@types/jest": "^24.0.25",


### PR DESCRIPTION
In a vite app, an issue occurs when both `@uniswap/sdk-core` and `@uniswap/router-sdk` are imported at the same time. A minimal repro can be found here: https://github.com/keithbro-imx/vite-uniswap-repro

In the browser, the following error is visible:

```
Uncaught TypeError: r.BigInt is not a function
```

`r` here is JSBI.

Using yalc locally I was able to point at a local build of this library, and I get the error:

```
Uncaught ReferenceError: require is not defined
```

Not exactly the same error, but this was resolved by adding the `module` option to the package.json. After this, both libraries could be imported and used at the same time.

I also added jsbi as a dependency (the same version constraints as core sdk for consistency), as this may also be contributing to the problem, though I wasn't able to confirm that.

