### PR TITLE
chore: bump to 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "1.7.1",
+  "version": "1.7.3",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
We will skip 1.7.2, and instead bump to 1.7.3, because previously there was a version bump to 1.7.2 that got [reverted](https://github.com/Uniswap/router-sdk/commit/03663bc98ec6fcb482f2aefcf50797106abb7836) later.