### PR TITLE
chore: bump to v1.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "1.7.1",
+  "version": "1.7.4",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Mistakenly published v1.7.4 without including https://github.com/Uniswap/router-sdk/pull/58, so v1.7.4 will be the same as v1.7.3.

This PR is to release https://github.com/Uniswap/router-sdk/pull/58